### PR TITLE
forbiddenfruit 0.1.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,10 +37,9 @@ about:
   description: |
     This project aims to help you reach heaven while writing tests, but it may lead you to hell if used on production code.
     It basically allows you to patch built-in objects, declared in C through python.
-  license: LGPL-3.0-only OR MIT
-  license_family: Other
+  license: MIT
+  license_family: MIT
   license_file:
-    - COPYING
     - COPYING.mit
   doc_url: https://clarete.li/forbiddenfruit/
   dev_url: https://github.com/clarete/forbiddenfruit

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,10 +34,16 @@ test:
 about:
   home: https://github.com/clarete/forbiddenfruit
   summary: Patch python built-in objects
-  license: LGPL-3.0-only & MIT
+  description: |
+    This project aims to help you reach heaven while writing tests, but it may lead you to hell if used on production code.
+    It basically allows you to patch built-in objects, declared in C through python.
+  license: LGPL-3.0-only OR MIT
+  license_family: Other
   license_file:
     - COPYING
     - COPYING.mit
+  doc_url: https://clarete.li/forbiddenfruit/
+  dev_url: https://github.com/clarete/forbiddenfruit
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,16 +10,16 @@ source:
   sha256: e3f7e66561a29ae129aac139a85d610dbf3dd896128187ed5454b6421f624253
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
   run:
-    - python >=3.7
+    - python
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
 


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-8148](https://anaconda.atlassian.net/browse/PKG-8148)
- [Upstream repository](https://github.com/clarete/forbiddenfruit)
- [Upstream changelog/diff]()
- Relevant dependency PRs:
  - `forbiddenfruit` ➡️ `python-blockbuster` ➡️ `langchain-core` ➡️ `langchain`

### Explanation of changes:

- Fork from Conda Forge
- Remove noarch
- Update build script
- Fix python pinnings
- Update about section


[PKG-8148]: https://anaconda.atlassian.net/browse/PKG-8148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ